### PR TITLE
Fix animations for tromboners in custom backgrounds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -400,3 +400,6 @@ FodyWeavers.xsd
 riderModule.iml
 /_ReSharper.Caches/
 .idea/
+
+# macOS metadata files
+.DS_Store

--- a/AutoToot/AutoToot.csproj
+++ b/AutoToot/AutoToot.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFramework>netstandard2.0</TargetFramework>
+        <TargetFramework>net472</TargetFramework>
         <AssemblyName>AutoToot</AssemblyName>
         <Description>Auto play for Trombone Champ.</Description>
         <Version>1.2.4</Version>
@@ -23,24 +23,8 @@
     </ItemGroup>
 
     <ItemGroup>
-        <Reference Include="0Harmony">
-            <HintPath>$(TromboneChampDir)\BepInEx\core\0Harmony.dll</HintPath>
-        </Reference>
-        <Reference Include="Assembly-CSharp">
-            <HintPath>$(TromboneChampDir)\TromboneChamp_Data\Managed\Assembly-CSharp-nstrip.dll</HintPath>
-        </Reference>
-        <Reference Include="UnityEngine">
-            <HintPath>$(TromboneChampDir)\TromboneChamp_Data\Managed\UnityEngine.dll</HintPath>
-        </Reference>
-        <Reference Include="UnityEngine.CoreModule">
-            <HintPath>$(TromboneChampDir)\TromboneChamp_Data\Managed\UnityEngine.CoreModule.dll</HintPath>
-        </Reference>
-        <Reference Include="UnityEngine.InputLegacyModule">
-            <HintPath>$(TromboneChampDir)\TromboneChamp_Data\Managed\UnityEngine.InputLegacyModule.dll</HintPath>
-        </Reference>
-        <Reference Include="UnityEngine.UI">
-            <HintPath>$(TromboneChampDir)\TromboneChamp_Data\Managed\UnityEngine.UI.dll</HintPath>
-        </Reference>
+        <PackageReference Include="TromboneChamp.GameLibs" Version="1.14.0" />
+        <PackageReference Include="TromboneChamp.TrombLoader" Version="2.1.0" />
     </ItemGroup>
 
   <Target Name="PostBuild" AfterTargets="PostBuildEvent">

--- a/AutoToot/Bot.cs
+++ b/AutoToot/Bot.cs
@@ -49,7 +49,7 @@ public class Bot
         _gameController = gameController;
         _humanPuppetController = gameController.puppet_humanc;
         _backgroundPuppetController = null;
-        _bg = GameObject.Find("_Background(Clone)");
+        _bg = gameController.bgcontroller.fullbgobject;
         if (_bg) {
             _backgroundPuppetController = _bg.GetComponent<BackgroundPuppetController>();
         }

--- a/AutoToot/Bot.cs
+++ b/AutoToot/Bot.cs
@@ -32,6 +32,7 @@ using System.Security.Permissions;
 using AutoToot.Helpers;
 using BepInEx.Logging;
 using UnityEngine;
+using TrombLoader.Data;
 
 #pragma warning disable CS0618
 [assembly: SecurityPermission(SecurityAction.RequestMinimum, SkipVerification = true)]
@@ -47,6 +48,11 @@ public class Bot
     {
         _gameController = gameController;
         _humanPuppetController = gameController.puppet_humanc;
+        _backgroundPuppetController = null;
+        _bg = GameObject.Find("_Background(Clone)");
+        if (_bg) {
+            _backgroundPuppetController = _bg.GetComponent<BackgroundPuppetController>();
+        }
 
         _noteHolderPosition = GameObject.Find(NotesHolderPath)?.GetComponent<RectTransform>();
         _pointer = GameObject.Find(CursorPath)?.GetComponent<RectTransform>();
@@ -95,6 +101,9 @@ public class Bot
             _pointer.anchoredPosition = pointerPosition;
 
             _humanPuppetController.doPuppetControl(-pointerY / GameCanvasSize * 2);
+            if (_backgroundPuppetController){
+                _backgroundPuppetController.DoPuppetControl(-pointerY / GameCanvasSize * 2, _gameController.vibratoamt);
+            }
         }
     }
 
@@ -139,6 +148,8 @@ public class Bot
 
     private readonly GameController _gameController;
     private readonly HumanPuppetController _humanPuppetController;
+    private readonly GameObject _bg;
+    private readonly BackgroundPuppetController _backgroundPuppetController;
     private readonly RectTransform _noteHolderPosition;
     private readonly RectTransform _pointer;
 


### PR DESCRIPTION
This PR fixes extra tromboners placed in custom backgrounds so that they still dance and toot when AutoToot is enabled. This change introduces TrombLoader as a dependency, as the background tromboners use a custom `BackgroundPuppetController` included with TrombLoader.

Because of this, you'll probably want to update the Thunderstore page to include TrombLoader as a dependancy.